### PR TITLE
adding hwflwctl support for NUCLEO_L476RG

### DIFF
--- a/libraries/rpc/rpc.cpp
+++ b/libraries/rpc/rpc.cpp
@@ -148,7 +148,6 @@ bool RPC::call(const char *request, char *reply) {
             for (; cur_method->name != NULL; cur_method++) {
                 if (strcmp(cur_method->name, args.method_name) == 0) {
                     (cur_method->method_caller)(p, &args, &r);
-                    r.putData<const char*>(cur_method->name);
                     return true;
                 }
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mbed-ls
 project-generator>=0.8.11,<0.9.0
 junit-xml
 requests
+pyYAML

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='mbed-tools',
       url='https://github.com/mbedmicro/mbed',
       packages=find_packages(),
       license=LICENSE,
-      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.8.11,<0.9.0", "junit-xml", "requests"])
+      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.8.11,<0.9.0", "junit-xml", "requests", "pyYAML"])
 
 # Restore previous private_settings if needed
 if backup:


### PR DESCRIPTION
adding changes to support hardware flow control in NUCLEO_L476RG Target.

5 files changed.

[L4_report.zip](https://github.com/mridup/mbed/files/214402/L4_report.zip)
